### PR TITLE
gts4lv-common: Fix symlink path to wlan_mac.bin

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -130,7 +130,7 @@ $(WCNSS_MAC_SYMLINK): $(LOCAL_INSTALLED_MODULE)
 	@echo "WCNSS MAC bin link: $@"
 	@mkdir -p $(dir $@)
 	@rm -rf $@
-	$(hide) ln -sf /persist/$(notdir $@) $@
+	$(hide) ln -sf /mnt/vendor/persist/$(notdir $@) $@
 
 ALL_DEFAULT_INSTALLED_MODULES += $(WCNSS_INI_SYMLINK) $(WCNSS_MAC_SYMLINK)
 


### PR DESCRIPTION
 * /persist does not exist anymore.